### PR TITLE
Allow colelcitng postfix stats for relay-mode

### DIFF
--- a/postfix_stats.py
+++ b/postfix_stats.py
@@ -196,7 +196,7 @@ class Parser(Thread):
             logger.debug(pline)
 
             component, facility = pline['facility'].split('/')
-            component = component.replace('postfix-', '')
+            component = component.replace('postfix-', '') if relay_mode else None
 
             for handler in handlers[facility]:
                 Handler.component = component
@@ -301,6 +301,7 @@ def main(logs, daemon=False, host='127.0.0.1', port=7777, concurrency=2, local_e
     return 0
 
 if __name__ == '__main__':
+    global relay_mode
     usage = "usage: %prog [options] file1 file2 ... fileN"
     opt_parser = OptionParser(usage)
     opt_parser.add_option("-v", "--verbose", dest="verbosity", default=0, action="count",
@@ -315,6 +316,8 @@ if __name__ == '__main__':
         help="Number of threads to spawn for handling lines", metavar="NUM")
     opt_parser.add_option("-l", "--local", dest="local_emails", default=[], action="append",
         help="Search for STRING in incoming email addresses and incr stat NAME and if COUNT, count in incoming - STRING,NAME,COUNT", metavar="LOCAL_TUPLE")
+    opt_parser.add_option("-r", "--relay-mode", dest="relay", default=False, action="store_true",
+        help="Activate the aggregator in relay-mode")
 
     (options, args) = opt_parser.parse_args()
 
@@ -324,5 +327,7 @@ if __name__ == '__main__':
         logger.setLevel(logging.DEBUG)
     else:
         logger.setLevel(logging.ERROR)
+
+    relay_mode = options.relay
 
     sys.exit(main(args, **options.__dict__))

--- a/postfix_stats.py
+++ b/postfix_stats.py
@@ -29,10 +29,12 @@ stats_lock = Lock()
 
 stats = {}
 stats['recv'] = {
+    'relay_status': defaultdict(lambda: defaultdict(int)),
     'status': defaultdict(int),
     'resp_codes': defaultdict(int),
 }
 stats['send'] = {
+    'relay_status': defaultdict(lambda: defaultdict(int)),
     'status': defaultdict(int),
     'resp_codes': defaultdict(int),
 }
@@ -40,6 +42,7 @@ stats['in'] = {
     'status': defaultdict(int),
     'resp_codes': defaultdict(int),
 }
+stats['relay_clients'] = defaultdict(lambda: defaultdict(int))
 stats['clients'] = defaultdict(int)
 stats['local'] = defaultdict(int)
 
@@ -49,6 +52,7 @@ local_addresses = {}
 class Handler(object):
     filter_re = re.compile(r'(?!)')
     facilities = None
+    component = None
 
     def __init__(self, *args, **kwargs):
         assert isinstance(self.filter_re, re._pattern_type)
@@ -142,7 +146,10 @@ class SmtpHandler(Handler):
     def handle(self, message_id=None, to_email=None, relay=None, conn_use=None, delay=None, delays=None, dsn=None, status=None, response=None):
         with stats_lock:
             stat = 'recv' if '127.0.0.1' in relay else 'send'
-            stats[stat]['status'][status] += 1
+            if self.component is None:
+                stats[stat]['status'][status] += 1
+            else:
+                stats[stat]['relay_status'][self.component][status] += 1
             stats[stat]['resp_codes'][dsn] += 1
 
 
@@ -154,8 +161,11 @@ class SmtpdHandler(Handler):
     def handle(self, message_id=None, client_hostname=None, client_ip=None, orig_client_hostname=None, orig_client_ip=None):
         ip = orig_client_ip or client_ip
         with stats_lock:
-            stats['clients'][ip] += 1
 
+            if self.component is None:
+                stats['clients'][ip] += 1
+            else:
+                stats['relay_clients'][self.component][ip] += 1
 
 class Parser(Thread):
     line_re = re.compile(r'\A(?P<iso_date>\D{3}\s+\d{1,2}\s+\d{2}:\d{2}:\d{2})\s+(?P<source>.+?)\s+(?P<facility>.+?)\[(?P<pid>\d+?)\]:\s(?P<message>.*)\Z')
@@ -185,9 +195,11 @@ class Parser(Thread):
             pline = pln.groupdict()
             logger.debug(pline)
 
-            facility = pline['facility'].split('/')
+            component, facility = pline['facility'].split('/')
+            component = component.replace('postfix-', '')
 
-            for handler in handlers[facility[-1]]:
+            for handler in handlers[facility]:
+                Handler.component = component
                 handler.parse(pline['message'])
 
 


### PR DESCRIPTION
Some postfix servers run on relay-mode. This change allows them to use
this aggregator seemlessly by providing an extra dimension of the
component of the postfix facilty that is being relayed to. The structure
of the response messages also changes a bit to accomodate this change.